### PR TITLE
Fix warnings in GitBucketLinkAnnotatorTest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/gitbucket/GitBucketLinkAnnotatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitbucket/GitBucketLinkAnnotatorTest.java
@@ -128,6 +128,6 @@ public class GitBucketLinkAnnotatorTest {
         MarkupText markupText = new MarkupText(originalText);
         GitBucketLinkAnnotator annotator = new GitBucketLinkAnnotator();
         annotator.annotate(markupText, GITBUCKET_URL);
-        assertEquals(expectedAnnotatedText, markupText.toString());
+        assertEquals(expectedAnnotatedText, markupText.toString(false));
     }
 }


### PR DESCRIPTION
I removed AbstractProject/Build and started using FreeStyleProject/Build directly.

I know about the [formatting issue](https://github.com/ArloL/gitbucket-plugin/commit/8e02058e3418ea673ab04d58ee926f4d6641d5b6#diff-01ec07242da121849b2dc1469560c22bR61) and will it fix it in a seperate PR in which I will run Eclipse's Cleanup on the project.
