### PR TITLE
use repository.clone_url instead of repository.url

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitbucket/GitBucketPushRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/gitbucket/GitBucketPushRequest.java
@@ -84,6 +84,10 @@ public class GitBucketPushRequest {
                 if ("private".equals(param)) {
                     return "private_";
                 }
+                // TODO: can't we use JavaIdentifierTransformer.CAMEL_CASE ?
+                if("clone_url".equals(param)) {
+                  return "cloneUrl";
+                }
                 return param;
             }
 
@@ -145,6 +149,8 @@ public class GitBucketPushRequest {
 
         private String url;
 
+        private String cloneUrl;
+
         private String description;
 
         private Integer forks;
@@ -170,6 +176,14 @@ public class GitBucketPushRequest {
 
         public void setUrl(String url) {
             this.url = url;
+        }
+
+        public String getCloneUrl() {
+            return cloneUrl;
+        }
+
+        public void setCloneUrl(String cloneUrl) {
+            this.cloneUrl = cloneUrl;
         }
 
         public String getDescription() {


### PR DESCRIPTION
As for Gitbucket ver 3.1, the payload posted from WebHook is different from the old ones.
Therefore, the "Build when a change is pushed to GitBucket" option is not working.
This pull request use `clone_url` instead of `url` for determining which jenkins job corresponds to the gitbucket url.
Following is the new payload sent from Gitbucket
```
{
  ...
  "repository": {
    ...
    "url": "http://<host>/gitbucket/api/v3/repos/<user>/<repos>",
    "http_url": "http://<host>/gitbucket/git/<user>/<repos>.git",
    "clone_url": "http://<host>/gitbucket/git/<user>/<repos>.git",
    "html_url": "http://<host>/gitbucket/<user>/<repos>"
  }
}
```
See https://github.com/takezoe/gitbucket/commit/32799cead7e0bb3642a48a018c29f5c7b50742cd
