### PR TITLE
mark Build Trigger Badge Plugin as optional

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitbucket/GitBucketBuildTriggerBadgeProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/gitbucket/GitBucketBuildTriggerBadgeProvider.java
@@ -27,7 +27,7 @@ import hudson.Extension;
 import hudson.model.Cause;
 import org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeProvider;
 
-@Extension
+@Extension(optional=true)
 public class GitBucketBuildTriggerBadgeProvider extends BuildTriggerBadgeProvider {
 
     


### PR DESCRIPTION
Before this commit, jenkins outputs following log if this plugin is not installed.

    java.lang.ClassNotFoundException: org.jenkinsci.plugins.buildtriggerbadge.provider.BuildTriggerBadgeProvider